### PR TITLE
fix: handle incoming links

### DIFF
--- a/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
+++ b/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
@@ -145,7 +145,7 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                     resAction = IntentAction.valueOf("EDIT")
                 }
                 Intent.ACTION_VIEW -> {
-                    if(data != null) {
+                    if (data != null) {
                         result["uri"] = data.toString()
                     }
                     resAction = IntentAction.valueOf("VIEW")

--- a/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
+++ b/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
@@ -145,6 +145,9 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                     resAction = IntentAction.valueOf("EDIT")
                 }
                 Intent.ACTION_VIEW -> {
+                    if(data != null) {
+                        result["uri"] = data.toString()
+                    }
                     resAction = IntentAction.valueOf("VIEW")
                     getResolvedContent(data!!, type!!, result)
                 }


### PR DESCRIPTION
Updated **Intent.ACTION_VIEW** to handle incoming links.
 
Changes
- If data (the incoming link) is not null, the URI is extracted and stored in the result map with the key **uri**.

