### PR TITLE
Fix crash on cold start for custom scheme deep links

### DIFF
--- a/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
+++ b/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
@@ -149,8 +149,8 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                         result["uri"] = data.toString()
                         Log.i(logTag, " dataValueView=$data")
                     }
-                    if (data != null && !data.toString().contains("https://albums")) {
-                            getResolvedContent(data, type!!, result)
+                    if (data != null && type != null && !data.toString().contains("https://albums")) {
+                            getResolvedContent(data, type, result)
                     }
                     resAction = IntentAction.valueOf("VIEW")
                 }

--- a/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
+++ b/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
@@ -149,7 +149,7 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                         result["uri"] = data.toString()
                         Log.i(logTag, " dataValueView=$data")
                     }
-                    if (data != null && type != null && !data.toString().contains("https://albums")) {
+                    if (data != null && type != null) {
                             getResolvedContent(data, type, result)
                     }
                     resAction = IntentAction.valueOf("VIEW")


### PR DESCRIPTION
# Pull Request Description ⛓️

Fix NullPointerException when app is opened via custom scheme URLs (like ente://) which don't have a MIME type. Added null check for type before calling getResolvedContent.
